### PR TITLE
Rectified Notice State Bug

### DIFF
--- a/noticeboard/android/app/build.gradle
+++ b/noticeboard/android/app/build.gradle
@@ -33,7 +33,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/noticeboard/android/app/src/main/java/io/flutter/app/FlutterMultiDexApplication.java
+++ b/noticeboard/android/app/src/main/java/io/flutter/app/FlutterMultiDexApplication.java
@@ -1,0 +1,25 @@
+// Generated file.
+//
+// If you wish to remove Flutter's multidex support, delete this entire file.
+//
+// Modifications to this file should be done in a copy under a different name
+// as this file may be regenerated.
+
+package io.flutter.app;
+
+import android.app.Application;
+import android.content.Context;
+import androidx.annotation.CallSuper;
+import androidx.multidex.MultiDex;
+
+/**
+ * Extension of {@link android.app.Application}, adding multidex support.
+ */
+public class FlutterMultiDexApplication extends Application {
+  @Override
+  @CallSuper
+  protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+    MultiDex.install(this);
+  }
+}

--- a/noticeboard/android/build.gradle
+++ b/noticeboard/android/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.21'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.google.gms:google-services:4.3.10'
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.google.gms:google-services:4.3.14'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -27,6 +27,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/noticeboard/android/gradle/wrapper/gradle-wrapper.properties
+++ b/noticeboard/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/noticeboard/ios/Flutter/AppFrameworkInfo.plist
+++ b/noticeboard/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/noticeboard/ios/Flutter/AppFrameworkInfo.plist
+++ b/noticeboard/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/noticeboard/lib/bloc/list_notices_bloc.dart
+++ b/noticeboard/lib/bloc/list_notices_bloc.dart
@@ -91,7 +91,9 @@ class ListNoticesBloc {
 
     _markReadStream.listen((object) async {
       object.read = true;
-      updateUi(object);
+      if(!object.fromDeepLink){
+        updateUi(object);
+      }
       var obj = {
         "keyword": "read",
         "notices": [object.id]

--- a/noticeboard/lib/models/notice_intro.dart
+++ b/noticeboard/lib/models/notice_intro.dart
@@ -8,6 +8,7 @@ class NoticeIntro {
   final String? department;
   bool? read;
   bool? starred;
+  bool fromDeepLink = false;
 
   NoticeIntro({
     this.id,

--- a/noticeboard/lib/services/auth/auth_repository.dart
+++ b/noticeboard/lib/services/auth/auth_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
+import 'package:noticeboard/bloc/list_notices_bloc.dart';
 import 'package:noticeboard/global/global_functions.dart';
 import 'package:noticeboard/models/notice_content.dart';
 import 'package:noticeboard/models/notice_intro.dart';
@@ -54,7 +55,12 @@ class AuthRepository {
             read: notice.read,
             starred: notice.starred,
           );
+          // This is to let the list_notices_bloc mark read sink no to not call update UI func
+          noticeIntro.fromDeepLink = true;
           // print(notice.content);
+          //If notice is accessed via deeplink , then also state shud be marked as read
+          final ListNoticesBloc listNoticesBloc = ListNoticesBloc();
+          listNoticesBloc.markReadSink.add(noticeIntro);
           navigatorKey.currentState!.pushNamed(
             noticeDetailRoute,
             arguments: noticeIntro,

--- a/noticeboard/lib/services/auth/auth_repository.dart
+++ b/noticeboard/lib/services/auth/auth_repository.dart
@@ -57,8 +57,7 @@ class AuthRepository {
           );
           // This is to let the list_notices_bloc mark read sink no to not call update UI func
           noticeIntro.fromDeepLink = true;
-          // print(notice.content);
-          //If notice is accessed via deeplink , then also state shud be marked as read
+          //If notice is accessed via deeplink , then also state should be marked as read
           final ListNoticesBloc listNoticesBloc = ListNoticesBloc();
           listNoticesBloc.markReadSink.add(noticeIntro);
           navigatorKey.currentState!.pushNamed(


### PR DESCRIPTION
# Description

This PR rectifies the notice state bug (when a notice is opened via a deeplink , the notice is not shown as read)

Closes #18 

## Type of change
Bug Patch

## Technicalities of change
I added a new field in the noticeIntro obj model to check whether the notice is via a deeplink or not. In the auth repository, if the notice is via a deep link , i added it to the mark read sink and wrote a conditional so that updateUI wouldn't be called for such a case when notice is via a deep link as that was erroroneous

## Demo

https://github.com/IMGIITRoorkee/noticeboard-mobile-app/assets/122373207/23f94b86-688c-4442-a817-144f3db756a6





