### PR TITLE
Added about us in profile screen

### DIFF
--- a/noticeboard/lib/bloc/profile_bloc.dart
+++ b/noticeboard/lib/bloc/profile_bloc.dart
@@ -30,6 +30,8 @@ class ProfileBloc {
         feedbackHandler();
       } else if (event == ProfileEvents.notificationSettingsEvent) {
         notificationSettingsHandler();
+      } else if (event == ProfileEvents.aboutUsEvent) {
+        aboutUsHandler();
       }
     });
   }
@@ -73,6 +75,13 @@ class ProfileBloc {
         Uri.parse(url),
         mode: LaunchMode.externalApplication,
       );
+    }
+  }
+
+  void aboutUsHandler() async {
+    const url = "https://channeli.in/maintainer_site/";
+    if (await canLaunchUrl(Uri.parse(url))) {
+      await launchUrl(Uri.parse(url), mode: LaunchMode.inAppWebView);
     }
   }
 

--- a/noticeboard/lib/bloc/profile_bloc.dart
+++ b/noticeboard/lib/bloc/profile_bloc.dart
@@ -51,7 +51,7 @@ class ProfileBloc {
     const String playStoreurl =
         'https://play.google.com/store/apps/details?id=com.img.noticeboard&hl=en_US&gl=IN';
     const String iosUrl =
-        "https://www.apple.com/in/app-store/"; // TODO: Change to actual app url on app store
+        "https://apps.apple.com/in/app/channel-i-noticeboard/id6443708603"; 
 
     late String url;
 

--- a/noticeboard/lib/enum/profile_enum.dart
+++ b/noticeboard/lib/enum/profile_enum.dart
@@ -2,5 +2,6 @@ enum ProfileEvents {
   logoutEvent,
   bookmarksEvent,
   feedbackEvent,
-  notificationSettingsEvent
+  notificationSettingsEvent,
+  aboutUsEvent
 }

--- a/noticeboard/lib/screens/profile.dart
+++ b/noticeboard/lib/screens/profile.dart
@@ -117,6 +117,8 @@ class _ProfileState extends State<Profile> {
                       'Notification settings',
                       ProfileEvents.notificationSettingsEvent),
                   sizedBox(20.0),
+                  buildMenuItem(aboutUsIcon, "About us", ProfileEvents.aboutUsEvent),
+                  sizedBox(20.0),
                   buildMenuItem(logoutIcon, 'Logout', ProfileEvents.logoutEvent)
                 ],
               ),

--- a/noticeboard/lib/styles/profile_constants.dart
+++ b/noticeboard/lib/styles/profile_constants.dart
@@ -34,6 +34,10 @@ Icon logoutIcon = Icon(
   Icons.exit_to_app,
   color: globalBlue,
 );
+Icon aboutUsIcon = Icon(
+  Icons.person_search_sharp,
+  color: globalBlue,
+);
 
 Container divider(double width) {
   return Container(


### PR DESCRIPTION
# Problem
No about us link in profile
Closes #21 

# Solution
Used webview_flutter(https://pub.dev/packages/webview_flutter) package for the web view as flutter_web_view is dart3 incompatible. Just added an event called aboutUs in profie_enum , used the package to handle the event in profile_bloc sink.


# Demo of Change
https://github.com/IMGIITRoorkee/noticeboard-mobile-app/assets/122373207/53cdb602-b953-4600-9a68-3941bfdff436





