### PR TITLE
Added Github Actions Workflows to NoticeBoard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./noticeboard
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,13 +32,8 @@ jobs:
           channel: 'stable'
           flutter-version: '3.13.0'
 
+      - run: cd noticeboard
+      
       - run: flutter pub get
 
       - run: flutter analyze .
-
-      - run: flutter build apk --release
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: release-apk
-          path: build/app/outputs/apk/release/app-release.apk

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Setup actions
+        working-directory: ./noticeboard
 
       # Note: This workflow uses the latest stable version of the Dart SDK.
       # You can specify other versions if desired, see documentation here:
@@ -31,8 +33,6 @@ jobs:
         with:
           channel: 'stable'
           flutter-version: '3.13.0'
-
-      - run: cd noticeboard
       
       - run: flutter pub get
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,12 +12,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./noticeboard
 
     steps:
       - uses: actions/checkout@v3
-      - name: Setup actions
-        working-directory: ./noticeboard
-
+      
       # Note: This workflow uses the latest stable version of the Dart SDK.
       # You can specify other versions if desired, see documentation here:
       # https://github.com/dart-lang/setup-dart/blob/main/README.md


### PR DESCRIPTION
# Issue
Closes #22 

# Details
This PR adds two workflows to the repo namely noticeboard analyzer and release. On direct push to master , the release workflow gets triggered which builds a release apk and runs flutter analyze. The analyzer workflow runs flutter analyze on every pull request to beta or master

# Demo
<img width="1512" alt="Screenshot 2024-01-14 at 11 10 55 PM" src="https://github.com/IMGIITRoorkee/noticeboard-mobile-app/assets/122373207/8c88f969-d513-4f85-bfd8-ac23fa545081">
