### PR TITLE
Feat: In Notice Navigation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: '3.13.0'
+          flutter-version: '3.19.1'
 
       - run: flutter pub get
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,8 +33,15 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: '3.13.0'
+          flutter-version: '3.19.1'
       
       - run: flutter pub get
 
       - run: flutter analyze .
+
+      - run: flutter build apk --release
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: NoticeBoard
+          path: build/app/outputs/apk/release/NoticeBoardApp.apk

--- a/noticeboard/android/build.gradle
+++ b/noticeboard/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.21'
+    ext.kotlin_version = '1.9.23'
     repositories {
         google()
         jcenter()

--- a/noticeboard/lib/bloc/list_notices_bloc.dart
+++ b/noticeboard/lib/bloc/list_notices_bloc.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:noticeboard/models/notice_detail_route_arguments.dart';
 import 'package:noticeboard/models/paginated_info.dart';
 import 'package:noticeboard/repository/list_notices_repository.dart';
 import '../global/global_constants.dart';
@@ -91,7 +92,7 @@ class ListNoticesBloc {
 
     _markReadStream.listen((object) async {
       object.read = true;
-      if(!object.fromDeepLink){
+      if (!object.fromDeepLink) {
         updateUi(object);
       }
       var obj = {
@@ -187,11 +188,28 @@ class ListNoticesBloc {
       await fetchBookmarkedNotices();
   }
 
-  void pushNoticeDetail(NoticeIntro noticeIntro) {
+  void pushNoticeDetail(NoticeIntro noticeIntro,
+      List<NoticeIntro?>? listOfNotices, ListNoticesBloc listNoticesBloc) {
     if (!noticeIntro.read!) markReadSink.add(noticeIntro);
     previousRoute = bottomNavigationRoute;
     navigatorKey.currentState!
-        .pushNamed(noticeDetailRoute, arguments: noticeIntro)
+        .pushNamed(noticeDetailRoute,
+            arguments: NoticeDetailArgument(
+                noticeIntro, listOfNotices, listNoticesBloc , false))
+        .then((value) => updateUi(value as NoticeIntro?));
+  }
+
+  void swipeBetweenNoticeDetail(
+    NoticeIntro noticeIntro,
+    List<NoticeIntro?>? listOfNotices,
+    ListNoticesBloc listNoticesBloc,
+    bool goingToPrevNotice
+  ) {
+    if (!noticeIntro.read!) markReadSink.add(noticeIntro);
+    navigatorKey.currentState!
+        .pushReplacementNamed(noticeDetailRoute,
+            arguments: NoticeDetailArgument(
+                noticeIntro, listOfNotices, listNoticesBloc , goingToPrevNotice))
         .then((value) => updateUi(value as NoticeIntro?));
   }
 
@@ -446,9 +464,12 @@ class ListNoticesBloc {
   }
 
   void updateUi(NoticeIntro? object) {
-    dynamicNoticeList![dynamicNoticeList!
-        .indexWhere((noticeIntro) => noticeIntro!.id == object!.id)] = object;
+    if(object != null){
+       dynamicNoticeList![dynamicNoticeList!
+        .indexWhere((noticeIntro) => noticeIntro!.id == object.id)] = object;
     _listNoticesSink
         .add(PaginatedInfo(list: dynamicNoticeList, hasMore: hasMore));
+    }
+   
   }
 }

--- a/noticeboard/lib/global/global_constants.dart
+++ b/noticeboard/lib/global/global_constants.dart
@@ -7,4 +7,4 @@ final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 String previousRoute = "";
 
 SnackBar noprevNoticeSnackBar =
-    const SnackBar(content: Text("You are already on the first notice!"));
+    const SnackBar(content: Text("You are already on the latest notice!"));

--- a/noticeboard/lib/global/global_constants.dart
+++ b/noticeboard/lib/global/global_constants.dart
@@ -5,3 +5,6 @@ final GlobalKey<ScaffoldMessengerState> snackKey =
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 String previousRoute = "";
+
+SnackBar noprevNoticeSnackBar =
+    const SnackBar(content: Text("You are already on the first notice!"));

--- a/noticeboard/lib/models/notice_detail_route_arguments.dart
+++ b/noticeboard/lib/models/notice_detail_route_arguments.dart
@@ -1,0 +1,12 @@
+import 'package:noticeboard/bloc/list_notices_bloc.dart';
+import 'package:noticeboard/models/notice_intro.dart';
+
+class NoticeDetailArgument {
+  NoticeIntro noticeIntro;
+  List<NoticeIntro?>? listOfNotices;
+  ListNoticesBloc listNoticesBloc;
+  bool goingtoPrevNotice = false;
+
+  NoticeDetailArgument(
+      this.noticeIntro, this.listOfNotices, this.listNoticesBloc , this.goingtoPrevNotice);
+}

--- a/noticeboard/lib/routes/routing.dart
+++ b/noticeboard/lib/routes/routing.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:noticeboard/models/notice_detail_route_arguments.dart';
 import 'package:noticeboard/models/notice_intro.dart';
 import 'package:noticeboard/screens/bottom_navigation.dart';
 import 'package:noticeboard/screens/profile.dart';
@@ -28,11 +29,42 @@ class MyRouter {
                   listNoticeMetaData: listNoticeMetaData,
                 ));
       case noticeDetailRoute:
-        NoticeIntro? noticeIntro = settings.arguments as NoticeIntro?;
-        return MaterialPageRoute(
+        NoticeDetailArgument noticeDetailArgument =
+            settings.arguments as NoticeDetailArgument;
+            if(!noticeDetailArgument.goingtoPrevNotice){
+              return MaterialPageRoute(
             builder: (context) => NoticeDetail(
-                  noticeIntro: noticeIntro,
-                ));
+                  noticeIntro: noticeDetailArgument.noticeIntro,
+                  listOfNotices: noticeDetailArgument.listOfNotices,
+                  listNoticesBloc: noticeDetailArgument.listNoticesBloc,
+                )
+                );
+            }
+            else{
+              return PageRouteBuilder(
+                transitionDuration: Duration(milliseconds: 100),
+            pageBuilder: (context, animation, secondaryAnimation) => NoticeDetail(
+                  noticeIntro: noticeDetailArgument.noticeIntro,
+                  listOfNotices: noticeDetailArgument.listOfNotices,
+                  listNoticesBloc: noticeDetailArgument.listNoticesBloc,
+                ),
+                transitionsBuilder: (context, animation, secondaryAnimation, child) {
+    var begin = Offset(-1.0, 0.0); // Start the animation from the left
+    var end = Offset.zero;
+    var curve = Curves.ease;
+
+    var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+
+    var offsetAnimation = animation.drive(tween);
+
+    return SlideTransition(
+      position: offsetAnimation,
+      child: child,
+    );
+  },
+                );
+            }
+        
       default:
         return MaterialPageRoute(builder: (context) => Launcher());
     }

--- a/noticeboard/lib/screens/list_notices.dart
+++ b/noticeboard/lib/screens/list_notices.dart
@@ -72,7 +72,7 @@ class _ListNoticesState extends State<ListNotices> {
   }
 
   void pushNoticeDetail(NoticeIntro noticeIntro) {
-    _listNoticesBloc.pushNoticeDetail(noticeIntro);
+    _listNoticesBloc.pushNoticeDetail(noticeIntro , _listNoticesBloc.dynamicNoticeList , _listNoticesBloc);
   }
 
   bool _handleScrollNotification(ScrollNotification scrollInfo) {

--- a/noticeboard/lib/screens/notice_detail.dart
+++ b/noticeboard/lib/screens/notice_detail.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:noticeboard/bloc/connectivity_status_bloc.dart';
+import 'package:noticeboard/bloc/list_notices_bloc.dart';
 import 'package:noticeboard/bloc/notice_detail_bloc.dart';
 import 'package:noticeboard/enum/current_widget_enum.dart';
 import 'package:noticeboard/enum/notice_content_enum.dart';
@@ -15,9 +18,15 @@ import '../global/global_functions.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import '../styles/notice_detail_consts.dart';
 
+// ignore: must_be_immutable
 class NoticeDetail extends StatefulWidget {
   final NoticeIntro? noticeIntro;
-  NoticeDetail({required this.noticeIntro});
+  List<NoticeIntro?>? listOfNotices;
+  ListNoticesBloc listNoticesBloc;
+  NoticeDetail(
+      {required this.noticeIntro,
+      required this.listOfNotices,
+      required this.listNoticesBloc});
 
   @override
   _NoticeDetailState createState() => _NoticeDetailState();
@@ -33,9 +42,10 @@ class _NoticeDetailState extends State<NoticeDetail> {
   WebViewController _webViewController = WebViewController();
   NoticeDetailBloc _noticeDetailBloc = NoticeDetailBloc();
   bool pdfAlreadyOpened = false;
-  bool gestureToPop = false;
-  bool gestureToNav = false;
+  bool snackBarShown = false;
+  bool isGestureZoom = false;
   late Timer _timer;
+  int currentIndex = 0;
 
   @override
   void initState() {
@@ -52,6 +62,18 @@ class _NoticeDetailState extends State<NoticeDetail> {
         _webViewController.reload();
       }
     });
+    for (int i = 0; i < widget.listOfNotices!.length; i++) {
+      if (widget.listOfNotices?[i]?.id == widget.noticeIntro?.id) {
+        currentIndex = i;
+      }
+    }
+    if (currentIndex == widget.listOfNotices!.length - 1) {
+      widget.listNoticesBloc.loadMore().whenComplete(() {
+        setState(() {
+          widget.listOfNotices = widget.listNoticesBloc.dynamicNoticeList;
+        });
+      });
+    }
     super.initState();
   }
 
@@ -94,8 +116,20 @@ class _NoticeDetailState extends State<NoticeDetail> {
         ),
         body: SizedBox.expand(
           child: GestureDetector(
+            onScaleUpdate: (details) async {
+              isGestureZoom = true;
+              await _webViewController.enableZoom(true);
+              return;
+              // Your zoom logic here
+            },
+            onScaleEnd: (details) {
+              isGestureZoom = false;
+            },
             onHorizontalDragStart: (details) {
-              if (details.localPosition.dx < 50.0 && Platform.isIOS) {
+              if (isGestureZoom) {
+                return;
+              }
+              if (details.localPosition.dx < 75.0 && Platform.isIOS) {
                 if (previousRoute == launchingRoute) {
                   navigatorKey.currentState!
                       .pushReplacementNamed(bottomNavigationRoute);
@@ -105,11 +139,31 @@ class _NoticeDetailState extends State<NoticeDetail> {
               }
             },
             onHorizontalDragUpdate: (details) {
-              if(details.delta.dx > 10){
-                // Forward swipe. Have to show previous notice
+              if (isGestureZoom) {
+                return;
               }
-              else if(details.delta.dx < -10){
+              if (details.delta.dx > 10) {
+                // Forward swipe. Have to show previous notice
+                if (currentIndex > 0)
+                  widget.listNoticesBloc.swipeBetweenNoticeDetail(
+                      widget.listOfNotices![currentIndex - 1]!,
+                      widget.listOfNotices,
+                      widget.listNoticesBloc,
+                      true);
+                else {
+                  if (!snackBarShown) {
+                    ScaffoldMessenger.of(context)
+                        .showSnackBar(noprevNoticeSnackBar);
+                    snackBarShown = true;
+                  }
+                }
+              } else if (details.delta.dx < -10) {
                 // Backward Swipe. Have to show next notice
+                widget.listNoticesBloc.swipeBetweenNoticeDetail(
+                    widget.listOfNotices![currentIndex + 1]!,
+                    widget.listOfNotices,
+                    widget.listNoticesBloc,
+                    false);
               }
             },
             child: PopScope(
@@ -169,7 +223,6 @@ class _NoticeDetailState extends State<NoticeDetail> {
       encoding: Encoding.getByName('utf-8'),
     );
     _webViewController
-      ..enableZoom(true)
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setNavigationDelegate(
           NavigationDelegate(onNavigationRequest: (navigation) async {
@@ -191,10 +244,14 @@ class _NoticeDetailState extends State<NoticeDetail> {
         }
         return NavigationDecision.navigate;
       }))
-      ..loadRequest(uri);
+      ..loadRequest(uri).then((value) async {
+        await _webViewController.enableZoom(true);
+      });
     return Container(
         padding: EdgeInsets.all(10.0),
-        child: WebViewWidget(controller: _webViewController));
+        child: WebViewWidget(controller: _webViewController , gestureRecognizers: Set()
+    ..add(Factory<PanGestureRecognizer>(() => PanGestureRecognizer()))
+    ..add(Factory<ScaleGestureRecognizer>(() => ScaleGestureRecognizer())),));
   }
 
   Container buildNoticeIntro(double _width) {

--- a/noticeboard/lib/screens/notice_detail.dart
+++ b/noticeboard/lib/screens/notice_detail.dart
@@ -33,6 +33,8 @@ class _NoticeDetailState extends State<NoticeDetail> {
   WebViewController _webViewController = WebViewController();
   NoticeDetailBloc _noticeDetailBloc = NoticeDetailBloc();
   bool pdfAlreadyOpened = false;
+  bool gestureToPop = false;
+  bool gestureToNav = false;
   late Timer _timer;
 
   @override
@@ -92,16 +94,22 @@ class _NoticeDetailState extends State<NoticeDetail> {
         ),
         body: SizedBox.expand(
           child: GestureDetector(
-            onPanUpdate: (details) {
-              // Can swipe anywhere and detects left swipe
-              if (details.delta.dx < 0 && Platform.isIOS) {
-                debugPrint("Left swipe occoured!");
+            onHorizontalDragStart: (details) {
+              if (details.localPosition.dx < 50.0 && Platform.isIOS) {
                 if (previousRoute == launchingRoute) {
                   navigatorKey.currentState!
                       .pushReplacementNamed(bottomNavigationRoute);
                 } else {
                   navigatorKey.currentState!.pop();
                 }
+              }
+            },
+            onHorizontalDragUpdate: (details) {
+              if(details.delta.dx > 10){
+                // Forward swipe. Have to show previous notice
+              }
+              else if(details.delta.dx < -10){
+                // Backward Swipe. Have to show next notice
               }
             },
             child: PopScope(


### PR DESCRIPTION
# Closes #17 

# Type of Change
New feature addition

# Technicalities of change
I have fixed the previous back swipe gesture by adding platform and changing the threshold for gesture detection. The flow is same as that of GMAIL app. When u swipe slightly to the left on IOS , you will be redirected back to list of notices. Also , while swiping in between notices , you will be navigating between notices. Have fixed the error log I received whilst in lab the other day. (Basically, just added a null check before assertion).
## How it works in brief:
I have passed the listnoticesbloc from list to notice detail. Reason -> Need to have same member params. I couldn't make it static because we need to have instances of the entire thing. So, I just get the entire list of notices in each noticeDetail screen and get the current index of the notice detail using id (Simple for loop). Then, I use gesture detector for detecting swipe gestures and do the reqd. In init state of notice detail, I also check if currentIndex is the last in the list. Then I fetch more notices and continue on. Additionally , if the user is already on the first notice and does a left swipe, a snackbar is shown saying the user is already on the first notice.

# Demo

https://github.com/IMGIITRoorkee/noticeboard-mobile-app/assets/122373207/308b9594-4dae-4b24-a1f1-08a38e94abc1









